### PR TITLE
add a new way to construct a Chess instance

### DIFF
--- a/src/chess.ts
+++ b/src/chess.ts
@@ -500,8 +500,13 @@ export class Chess {
   private _comments: Record<string, string> = {}
   private _castling: Record<Color, number> = { w: 0, b: 0 }
 
-  constructor(fen = DEFAULT_POSITION) {
-    this.load(fen)
+  constructor(fen = DEFAULT_POSITION, obj?:Chess) {
+    if(obj){
+      Object.assign(this, obj);
+      this.load(this.fen());
+    }else{
+        this.load(fen);
+    }
   }
 
   clear(keepHeaders = false) {


### PR DESCRIPTION
## Add a way to pass a object to the Chess constructor.

### How is it useful?
In my case i save a `Chess` instance in my Mongodb Database.
```javascript
mongoose.Schema({
  foo: {type: Bar, ...},
  chessBoard: {
     type: Mixed,
     default: new Chess(),
  }
})
```
So, when i need to get this information, it is no more a instance of Chess, it is just a Object.
```javascript
const board = new board(this.findOne(idBoard));
console.log(board instanceof Chess) //false
````
But, now i can pass the object to the constructor and invoke methods!
```javascript
const newBoard = new Chess(undefined, board.chessBoard)
console.log(newBoard instanceof Chess) //true
newBoard.moves()
````
