### PR TITLE
Union types constructor

### DIFF
--- a/src/chess.ts
+++ b/src/chess.ts
@@ -500,12 +500,12 @@ export class Chess {
   private _comments: Record<string, string> = {}
   private _castling: Record<Color, number> = { w: 0, b: 0 }
 
-  constructor(fen = DEFAULT_POSITION, obj?:Chess) {
-    if(obj){
-      Object.assign(this, obj);
+  constructor(value:(string | Chess) = DEFAULT_POSITION) {
+    if(value instanceof Chess){
+      Object.assign(this, value);
       this.load(this.fen());
     }else{
-        this.load(fen);
+        this.load(value);
     }
   }
 

--- a/src/chess.ts
+++ b/src/chess.ts
@@ -501,11 +501,11 @@ export class Chess {
   private _castling: Record<Color, number> = { w: 0, b: 0 }
 
   constructor(value:(string | Chess) = DEFAULT_POSITION) {
-    if(value instanceof Chess){
+    if(typeof value === 'string'){
+      this.load(value);
+    }else{
       Object.assign(this, value);
       this.load(this.fen());
-    }else{
-        this.load(value);
     }
   }
 


### PR DESCRIPTION
Now, instead of pass 2 params to class constructor, like: 
```Typescript
const board = new Chess(stringFen, chessObject)
```
You can pass any of these types (string or Chess)
```Typescript
const board1 = new Chess(stringFen) //String
const board2 = new Chess(chessObject) //Chess
const board3 = new Chess() //String as default (starter FEN)
```